### PR TITLE
Add ability to instantiate the json provider from fs interface

### DIFF
--- a/providers/json.go
+++ b/providers/json.go
@@ -3,8 +3,11 @@ package providers
 import (
 	"errors"
 	"fmt"
-	json "github.com/titanous/json5"
+	"io"
+	"io/fs"
 	"os"
+
+	json "github.com/titanous/json5"
 )
 
 type JSONProvider struct {
@@ -13,6 +16,27 @@ type JSONProvider struct {
 
 func NewJSONProvider(filePath string) (*JSONProvider, error) {
 	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed := map[string]interface{}{}
+
+	err = json.Unmarshal(contents, &parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &JSONProvider{parsedFile: parsed}, nil
+}
+
+func NewJSONProviderFromFs(fs fs.FS, filePath string) (*JSONProvider, error) {
+	file, err := fs.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	contents, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/json_test.go
+++ b/providers/json_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"embed"
 	"errors"
 	"fmt"
 	"os"
@@ -80,4 +81,20 @@ func TestJSONProvider_GetValue(t *testing.T) {
 			assert.Equal(t, test.expectedErr, err)
 		})
 	}
+}
+
+//go:embed test.config.json5
+var config embed.FS
+
+func TestNewJSONProviderFromFs(t *testing.T) {
+	jp, err := NewJSONProviderFromFs(config, "test.config.json5")
+	assert.Nil(t, err)
+
+	value, err := jp.GetValue([]string{"some"})
+	assert.Nil(t, err)
+	assert.Equal(t, "value", value)
+
+	value, err = jp.GetValue([]string{"nested", "key"})
+	assert.Nil(t, err)
+	assert.Equal(t, "value", value)
 }

--- a/providers/test.config.json5
+++ b/providers/test.config.json5
@@ -1,0 +1,6 @@
+{
+  some: "value",
+  nested: {
+    key: "value",
+  },
+}


### PR DESCRIPTION
This PR adds a new function allowing to create a new JSON provider by providing a struct instance implementing the io.fs interface, allowing for more flexibility.